### PR TITLE
ST-117: Post-scorer enhancements for pipeline integration

### DIFF
--- a/scorer/scorer.go
+++ b/scorer/scorer.go
@@ -68,6 +68,7 @@ func New(cfg Config) (Scorer, error) {
 	}, nil
 }
 
+
 // WithPrompt returns a function that sets a custom prompt for the scorer
 func WithPrompt(prompt string) func(*scorer) {
 	return func(s *scorer) {
@@ -90,6 +91,24 @@ func NewWithClient(client OpenAIClient, opts ...func(*scorer)) Scorer {
 	}
 	for _, opt := range opts {
 		opt(s)
+	}
+	return s
+}
+
+// NewWithClientAndOptions creates a new scorer with a custom OpenAI client and ScoringOptions
+func NewWithClientAndOptions(client OpenAIClient, prompt string, maxConcurrent int) Scorer {
+	s := &scorer{
+		client: client,
+		prompt: prompt,
+		config: Config{
+			MaxConcurrent: maxConcurrent,
+		},
+	}
+	if s.prompt == "" {
+		s.prompt = batchScorePrompt
+	}
+	if s.config.MaxConcurrent == 0 {
+		s.config.MaxConcurrent = 1
 	}
 	return s
 }
@@ -203,6 +222,133 @@ func (s *scorer) processConcurrently(ctx context.Context, batches [][]*reddit.Po
 	}
 
 	slog.Info("All posts scored successfully",
+		"total_posts", len(flatResults),
+		"total_batches", len(batches),
+		"mode", "concurrent",
+		"max_concurrent", s.config.MaxConcurrent)
+
+	return flatResults, nil
+}
+
+// ScorePostsWithContext evaluates and scores posts with additional context
+func (s *scorer) ScorePostsWithContext(ctx context.Context, contexts []ScoringContext, opts ...ScoringOption) ([]*ScoredPost, error) {
+	if contexts == nil {
+		return nil, errors.New("contexts cannot be nil")
+	}
+	
+	if len(contexts) == 0 {
+		return []*ScoredPost{}, nil
+	}
+	
+	// Extract posts from contexts for validation
+	posts := make([]*reddit.Post, len(contexts))
+	for i, context := range contexts {
+		if context.Post == nil {
+			return nil, fmt.Errorf("context at index %d has nil post", i)
+		}
+		if context.Post.ID == "" {
+			return nil, fmt.Errorf("post at index %d has empty ID", i)
+		}
+		posts[i] = context.Post
+	}
+
+	// Apply default options
+	options := &scoringOptions{
+		model: s.config.Model, // Default from config
+	}
+	
+	// Apply provided options
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	// Create batches of contexts
+	var batches [][]ScoringContext
+	for i := 0; i < len(contexts); i += maxBatchSize {
+		batch := contexts[i:min(i+maxBatchSize, len(contexts))]
+		batches = append(batches, batch)
+	}
+
+	// Process batches based on MaxConcurrent setting
+	if s.config.MaxConcurrent <= 1 {
+		return s.processContextsSequentially(ctx, batches, options)
+	}
+	return s.processContextsConcurrently(ctx, batches, options)
+}
+
+func (s *scorer) processContextsSequentially(ctx context.Context, batches [][]ScoringContext, options *scoringOptions) ([]*ScoredPost, error) {
+	var allResults []*ScoredPost
+	for i, batch := range batches {
+		// Extract posts from contexts
+		posts := make([]*reddit.Post, len(batch))
+		for j, context := range batch {
+			posts[j] = context.Post
+		}
+		
+		results, err := s.processBatchWithContext(ctx, posts, batch, options)
+		if err != nil {
+			return nil, fmt.Errorf("processing batch %d: %w", i, err)
+		}
+		allResults = append(allResults, results...)
+	}
+
+	slog.Info("All posts scored successfully with context",
+		"total_posts", len(allResults),
+		"total_batches", len(batches),
+		"mode", "sequential")
+
+	return allResults, nil
+}
+
+func (s *scorer) processContextsConcurrently(ctx context.Context, batches [][]ScoringContext, options *scoringOptions) ([]*ScoredPost, error) {
+	type batchResult struct {
+		index   int
+		results []*ScoredPost
+		err     error
+	}
+
+	// Semaphore to limit concurrent processing
+	sem := make(chan struct{}, s.config.MaxConcurrent)
+	results := make(chan batchResult, len(batches))
+
+	// Process batches concurrently
+	for i, batch := range batches {
+		go func(index int, batch []ScoringContext) {
+			sem <- struct{}{} // Acquire semaphore
+			defer func() { <-sem }() // Release semaphore
+
+			// Extract posts from contexts
+			posts := make([]*reddit.Post, len(batch))
+			for j, context := range batch {
+				posts[j] = context.Post
+			}
+			
+			batchResults, err := s.processBatchWithContext(ctx, posts, batch, options)
+			results <- batchResult{
+				index:   index,
+				results: batchResults,
+				err:     err,
+			}
+		}(i, batch)
+	}
+
+	// Collect results in order
+	allResults := make([][]*ScoredPost, len(batches))
+	for i := 0; i < len(batches); i++ {
+		result := <-results
+		if result.err != nil {
+			return nil, fmt.Errorf("processing batch %d: %w", result.index, result.err)
+		}
+		allResults[result.index] = result.results
+	}
+
+	// Flatten results
+	var flatResults []*ScoredPost
+	for _, batchResults := range allResults {
+		flatResults = append(flatResults, batchResults...)
+	}
+
+	slog.Info("All posts scored successfully with context",
 		"total_posts", len(flatResults),
 		"total_batches", len(batches),
 		"mode", "concurrent",

--- a/scorer/types.go
+++ b/scorer/types.go
@@ -11,6 +11,7 @@ import (
 // Scorer provides methods to score Reddit posts using ChatGPT
 type Scorer interface {
 	ScorePosts(ctx context.Context, posts []*reddit.Post) ([]*ScoredPost, error)
+	ScorePostsWithOptions(ctx context.Context, posts []*reddit.Post, opts ...ScoringOption) ([]*ScoredPost, error)
 }
 
 // ScoredPost represents a Reddit post with its AI-generated score
@@ -23,6 +24,7 @@ type ScoredPost struct {
 // Config holds the configuration for the scorer
 type Config struct {
 	OpenAIKey     string
+	Model         string
 	PromptText    string
 	MaxConcurrent int
 }
@@ -51,4 +53,19 @@ type scoreItem struct {
 	Title  string `json:"title"`
 	Score  int    `json:"score"`
 	Reason string `json:"reason"`
+}
+
+// ScoringOption is a functional option for configuring scoring behavior
+type ScoringOption func(*scoringOptions)
+
+// scoringOptions holds the options for a scoring request
+type scoringOptions struct {
+	model string
+}
+
+// WithModel sets the model for this scoring request
+func WithModel(model string) ScoringOption {
+	return func(opts *scoringOptions) {
+		opts.model = model
+	}
 }

--- a/scorer/types.go
+++ b/scorer/types.go
@@ -12,6 +12,7 @@ import (
 type Scorer interface {
 	ScorePosts(ctx context.Context, posts []*reddit.Post) ([]*ScoredPost, error)
 	ScorePostsWithOptions(ctx context.Context, posts []*reddit.Post, opts ...ScoringOption) ([]*ScoredPost, error)
+	ScorePostsWithContext(ctx context.Context, contexts []ScoringContext, opts ...ScoringOption) ([]*ScoredPost, error)
 }
 
 // ScoredPost represents a Reddit post with its AI-generated score
@@ -19,6 +20,12 @@ type ScoredPost struct {
 	Post   *reddit.Post
 	Score  int
 	Reason string
+}
+
+// ScoringContext represents a post with additional context for scoring
+type ScoringContext struct {
+	Post      *reddit.Post
+	ExtraData map[string]string // For comments, metadata, etc.
 }
 
 // Config holds the configuration for the scorer
@@ -60,12 +67,28 @@ type ScoringOption func(*scoringOptions)
 
 // scoringOptions holds the options for a scoring request
 type scoringOptions struct {
-	model string
+	model        string
+	promptText   string
+	extraContext map[string]string
 }
 
 // WithModel sets the model for this scoring request
 func WithModel(model string) ScoringOption {
 	return func(opts *scoringOptions) {
 		opts.model = model
+	}
+}
+
+// WithPromptTemplate sets a custom prompt template for this scoring request
+func WithPromptTemplate(prompt string) ScoringOption {
+	return func(opts *scoringOptions) {
+		opts.promptText = prompt
+	}
+}
+
+// WithExtraContext adds extra context data for template substitution
+func WithExtraContext(context map[string]string) ScoringOption {
+	return func(opts *scoringOptions) {
+		opts.extraContext = context
 	}
 }


### PR DESCRIPTION
## Summary
- Implemented ST-176: Add per-request model selection support
- Implemented ST-177: Add custom prompt template support

## Changes

### ST-176: Per-request model selection
- Added functional options pattern with `ScoringOption` type
- Added `WithModel()` function to override model per request
- Added `ScorePostsWithOptions()` method to Scorer interface
- Model selection priority: options > config > default (GPT4oMini)

### ST-177: Custom prompt template support
- Added support for Go template syntax in prompts ({{.PostTitle}}, {{.PostBody}}, etc.)
- Added `WithPromptTemplate()` option to override prompt per request
- Added `WithExtraContext()` option to pass additional template variables
- Added `ScorePostsWithContext()` method for scoring with extra context data
- Maintained backward compatibility with %s placeholder syntax

## Test plan
- [x] All existing tests pass
- [x] `make check` completes successfully
- [x] Example application runs without issues
- [x] Backward compatibility maintained

## Use cases
These enhancements enable the Some Things To Do pipeline to:
- Use different models for different phases (gatekeeper: gpt-3.5-turbo, enrichment: gpt-4o)
- Use custom prompt templates with variable substitution
- Pass additional context (like comments) to the enrichment phase

🤖 Generated with [Claude Code](https://claude.ai/code)